### PR TITLE
Re-order extra repos, rename headers, add text

### DIFF
--- a/_docs/info/ipsrepos.md
+++ b/_docs/info/ipsrepos.md
@@ -10,14 +10,10 @@ OmniOS takes a *layer cake* approach to packaging. The core OS contains
 the packages needed to build the OS, plus a few small frills (more
 shells, tmux/screen, etc.). Users are encouraged to either create their
 own package repositories for additional software they want to run (and where
-they like it to be installed) or use repositories published by other users.
+they like it to be installed) or use repositories published by other users
+found in "Extras by OmniOSce Community" below. 
 
-Maintainers of add-on repositories are encouraged to share their work with the
-community. If you wish to have your repository listed here, please get in
-touch [in the Lobby](https://gitter.im/omniosorg/Lobby) or via
-[#omnios on Freenode](http://webchat.freenode.net?randomnick=1&channels=%23omnios&uio=d4).
-
-## Repos
+## Core And Extra Repos by OmniOSce
 
 {:.bordered .responsive-table}
 | URL                                                         | Publisher    | Signed | Build Scripts                                                                                         | Notes                                       |
@@ -31,17 +27,24 @@ touch [in the Lobby](https://gitter.im/omniosorg/Lobby) or via
 | <https://pkg.omniosce.org/bloody/core/>                     | omnios       | no     | [master](https://github.com/omniosorg/omnios-build)                                                   | Core OS components (unstable)
 | <https://pkg.omniosce.org/bloody/extra/>                    | extra.omnios | no     | [master](https://github.com/omniosorg/omnios-extra)                                                   | Additional packages (unstable)
 
-## Unofficial Extras
+## Extras by OmniOSce Community
 
 {:.bordered .responsive-table}
 | URL                                      | Publisher          | Maintainer                             | Build Scripts                                                               | Notes                                                                        |
 |------------------------------------------|--------------------|----------------------------------------|-----------------------------------------------------------------------------|------------------------------------------------------------------------------|
-| <http://pkg.cs.umd.edu/>                 | cs.umd.edu         | Sergey Ivanov                          |                                                                             |                                                                              |
-| <http://pkg.niksula.hut.fi/>             | niksula.hut.fi     | pkg@niksula.hut.fi                     | <https://github.com/niksula/omnios-build>                                   | Signed packages; see the [instructions](http://pkg.niksula.hut.fi/)          |
-| <http://scott.mathematik.uni-ulm.de/>    | uulm.mawi          | Steffen Kram                           | [stefri/omnios-build](https://github.com/stefri/omnios-build)               |                                                                              |
-| <http://sfe.opencsw.org/localhostomnios> | localhostomnios    | SFE Community                          | <https://sourceforge.net/p/pkgbuild/code/HEAD/tree/spec-files-extra/trunk/> | Open for contribution                                                        |
-| <https://ips.qutic.com/>                 | application        | [qutic development](https://qutic.com) | <https://github.com/jfqd/omnios-userland>                                   | Userland packages; pull requests welcome                                     |          
+| <http://sfe.opencsw.org/localhostomnios> | localhostomnios    | @sfepackages and 3 more from SFE Community| <https://sourceforge.net/p/pkgbuild/code/HEAD/tree/spec-files-extra/trunk/> | Blog: https://sfe.opencsw.org; open for contribution and actively maintained, weekly updates                                                        |
+| <https://ips.qutic.com/>                 | application        | [qutic development](https://qutic.com) | <https://github.com/jfqd/omnios-userland>                                   | Userland packages; pull requests welcome; last update 2018-01                               |          
+| <http://pkg.niksula.hut.fi/>             | niksula.hut.fi     | pkg@niksula.hut.fi                     | <https://github.com/niksula/omnios-build>                                   | Signed packages; see the [instructions](http://pkg.niksula.hut.fi/)          |last update 2018-05
+| <http://pkg.cs.umd.edu/>                 | cs.umd.edu         | Sergey Ivanov                          |                                                                             |                                                                              |last update 2017-08
+| <http://scott.mathematik.uni-ulm.de/>    | uulm.mawi          | Steffen Kram                           | [stefri/omnios-build](https://github.com/stefri/omnios-build)               |last update 2016, is changing servers, may come back in 2019                                                                          |
 | <http://www.opencsw.org/>                | SysV packages      | OpenCSW                                | <https://sourceforge.net/p/gar/code/HEAD/tree/>                             | A collection of SysV packages (i.e. for use with the old pkgadd(1M) command) |
+
+Note that you as a user of these extra repositories are encouraged to get in touch with the maintainers of these repos. In many cases you can contribute and help improving by writing documentation, sending in build instructions for new software or simply testing packages and send in results. If you need more packages then you should ask for them.
+
+Maintainers of add-on repositories are encouraged to share their work with the
+community. If you wish to have your repository listed here, please get in
+touch [in the Lobby](https://gitter.im/omniosorg/Lobby) or via
+[#omnios on Freenode](http://webchat.freenode.net?randomnick=1&channels=%23omnios&uio=d4).
 
 Note that ms.omniti.com and perl.omniti.com hold packages built
 specifically for OmniTI's own use. While there is nothing secret or


### PR DESCRIPTION
Hi,
dead or rarely updated "Extra" repos should be identified by last updated.
Change headlines to express the community part.
I hope I didn't mess up the table layout.
I would like to make the community repos to cach eye much more but how?
The first paragraph is a bit long and pushed community repos down.
Thanks!